### PR TITLE
fix: Update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -37,12 +37,12 @@ jobs:
           java-version: '17'
 
       - name: Gradle をセットアップ
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-home-cache-cleanup: true
 
       - name: Gradle 依存関係をキャッシュ
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -56,7 +56,7 @@ jobs:
 
       - name: Detekt レポートをアップロード (失敗時)
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: detekt-reports
           path: |


### PR DESCRIPTION
Fixed the deprecation warning for GitHub Actions:
- actions/upload-artifact: v3 → v4 (v3 deprecated as of 2024-04-16)
- actions/cache: v3 → v4 (for consistency and latest features)
- gradle/gradle-build-action: v2 → v3 (for improved performance)

This resolves the error:
'This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3'