### PR TITLE
fix: Add missing GitHub Actions permissions for PR comments

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -23,6 +23,8 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: リポジトリをチェックアウト


### PR DESCRIPTION
Fixed the 403 'Resource not accessible by integration' error by adding required permissions to the GitHub Actions workflow:

- issues: write - Required for creating and deleting PR comments
- pull-requests: write - Required for PR-related operations

Error details:
- Status: 403 (Forbidden)
- Missing permissions: issues=write; pull_requests=write
- Operation: POST /repos/.../issues/.../comments

This enables the Detekt workflow to automatically post analysis results as PR comments without permission errors.