### PR TITLE
fix: Prevent workflow failure when Detekt finds issues

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -54,10 +54,12 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Detekt 静的解析を実行
+        id: detekt
         run: ./gradlew detekt --continue
+        continue-on-error: true
 
-      - name: Detekt レポートをアップロード (失敗時)
-        if: failure()
+      - name: Detekt レポートをアップロード
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: detekt-reports
@@ -66,14 +68,14 @@ jobs:
           retention-days: 7
 
       - name: Detekt SARIF レポートをアップロード
-        if: success() || failure()
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: app/build/reports/detekt/detekt.sarif
         continue-on-error: true
 
       - name: Detekt結果をPRコメントに投稿
-        if: github.event_name == 'pull_request' && (success() || failure())
+        if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Modified the Detekt workflow to continue successfully even when code quality issues are found, while still generating and uploading all reports:

Changes:
- Added 'continue-on-error: true' to Detekt analysis step
- Added 'id: detekt' to enable result referencing
- Changed report upload conditions from 'failure()' to 'always()'
- Updated SARIF upload condition to 'always()'
- Updated PR comment condition to always run for PRs

Benefits:
✅ Workflow succeeds even with Detekt violations
✅ All reports are always generated and uploaded
✅ PR comments are always posted with results
✅ GitHub Security tab always receives SARIF reports ✅ Detekt step failure is still visible in workflow details

This ensures continuous feedback while maintaining green build status for PRs with only code quality issues (not compilation errors).