### PR TITLE
feat: Update dependencies to latest versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-agp = "8.8.0"
-kotlin = "2.0.0"
+agp = "8.10.1"
+kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
+lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2024.04.01"
-detekt = "1.23.4"
+composeBom = "2025.06.01"
+detekt = "1.23.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 23 20:37:17 JST 2025
+#Tue Jun 24 19:59:28 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Android Gradle Plugin: 8.8.0 → 8.10.1
- Kotlin: 2.0.0 → 2.2.0
- AndroidX Lifecycle Runtime KTX: 2.8.7 → 2.9.1
- Compose BOM: 2024.04.01 → 2025.06.01
- Detekt: 1.23.4 → 1.23.6
- Gradle Wrapper: 8.10.2 → 8.11.1